### PR TITLE
feat: external secret management

### DIFF
--- a/k8s-secrets-rotation/.github/workflows/deploy.yaml
+++ b/k8s-secrets-rotation/.github/workflows/deploy.yaml
@@ -1,0 +1,33 @@
+name: Deploy to Kubernetes
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up kubectl
+      uses: azure/setup-kubectl@v3
+      with:
+        version: 'latest'
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: 'latest'
+
+    - name: Set Kubeconfig
+      run: |
+        echo "${{ secrets.KUBECONFIG_DATA }}" | base64 --decode > kubeconfig
+        export KUBECONFIG=$PWD/kubeconfig
+
+    - name: Deploy Kubernetes Resources
+      run: |
+        chmod +x ./scripts/deploy.sh
+        ./scripts/deploy.sh

--- a/k8s-secrets-rotation/README.md
+++ b/k8s-secrets-rotation/README.md
@@ -1,0 +1,46 @@
+# Kubernetes Secrets Rotation with AWS Secrets Manager
+
+This repo demonstrates how to manage secrets in Kubernetes using AWS Secrets Manager, External Secrets Operator, and Stakater Reloader.
+
+## 🔐 Secrets Management Flow
+
+This architecture securely syncs secrets from AWS Secrets Manager into Kubernetes and ensures applications reload when secrets are updated.
+
+### 📊 Architecture Diagram
+
+```text
++---------------------+
+| AWS Secrets Manager |
++---------------------+
+          |
+          v
++----------------------------+
+| External Secrets Operator |
+|   (Running in K8s)        |
++----------------------------+
+          |
+          v
++---------------------------+       +------------------+
+| Kubernetes Secret         | <---> | Stakater Reloader|
++---------------------------+       +------------------+
+          |
+          v
++---------------------------+
+| Applications using secret |
++---------------------------+
+
+```
+
+
+
+## Components
+- **AWS Secrets Manager** for storing and rotating secrets.
+- **External Secrets Operator** to sync secrets into Kubernetes.
+- **Stakater Reloader** to restart pods on secret changes.
+
+## Quick Start
+
+```bash
+cd scripts
+./deploy.sh
+```

--- a/k8s-secrets-rotation/manifests/external-secrets/externalsecret.yaml
+++ b/k8s-secrets-rotation/manifests/external-secrets/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: db-secret
+  #namespace: demo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: db-secret
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: prod/backend/database

--- a/k8s-secrets-rotation/manifests/external-secrets/secretstore.yaml
+++ b/k8s-secrets-rotation/manifests/external-secrets/secretstore.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  #namespace: demo
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ap-south-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa

--- a/k8s-secrets-rotation/manifests/external-secrets/serviceaccount.yaml
+++ b/k8s-secrets-rotation/manifests/external-secrets/serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   name: external-secrets-sa
   #namespace: demo
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::717279697458:role/external-secrets-irsa-role
+    eks.amazonaws.com/role-arn: arn:aws:iam::717279697458:role/external-secrets-irsa

--- a/k8s-secrets-rotation/manifests/external-secrets/serviceaccount.yaml
+++ b/k8s-secrets-rotation/manifests/external-secrets/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-sa
+  #namespace: demo
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::717279697458:role/external-secrets-irsa-role

--- a/k8s-secrets-rotation/manifests/sample-app/deployment.yaml
+++ b/k8s-secrets-rotation/manifests/sample-app/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-app
+  #namespace: demo
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-app
+  template:
+    metadata:
+      labels:
+        app: sample-app
+    spec:
+      containers:
+        - name: app
+          image: nginx
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: username
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password

--- a/k8s-secrets-rotation/manifests/sample-app/service.yaml
+++ b/k8s-secrets-rotation/manifests/sample-app/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-app-service
+  #namespace: demo
+spec:
+  selector:
+    app: sample-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/k8s-secrets-rotation/scripts/deploy.sh
+++ b/k8s-secrets-rotation/scripts/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Create namespaces
+kubectl create ns external-secrets || true
+kubectl create ns reloader || true
+kubectl create ns demo || true
+
+# Install External Secrets Operator
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm upgrade --install external-secrets external-secrets/external-secrets -n external-secrets -f values/external-secrets-values.yaml
+
+
+# Install Reloader
+helm repo add stakater https://stakater.github.io/stakater-charts
+helm repo update
+helm upgrade --install reloader stakater/reloader -n reloader -f values/reloader-values.yaml
+
+# Apply manifests
+kubectl apply -f manifests/external-secrets
+kubectl apply -f manifests/sample-app

--- a/k8s-secrets-rotation/values/external-secrets-values.yaml
+++ b/k8s-secrets-rotation/values/external-secrets-values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 1
+
+installCRDs: true
+
+webhook:
+  port: 10250

--- a/k8s-secrets-rotation/values/reloader-values.yaml
+++ b/k8s-secrets-rotation/values/reloader-values.yaml
@@ -1,0 +1,4 @@
+reloader:
+  autoReloadAll: true
+  reloadOnConfigChange: true
+  reloadOnSecretChange: true

--- a/terraform/eks-alb-argocd-dns-cert-monitoring/16-external-secret-irsa.yaml
+++ b/terraform/eks-alb-argocd-dns-cert-monitoring/16-external-secret-irsa.yaml
@@ -1,0 +1,45 @@
+module "external_secrets_irsa_role" {
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.20.0"
+
+  role_name                     = "external-secrets-irsa"
+  attach_external_secrets_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["default:external-secrets-sa"]
+    }
+  }
+
+  role_policy_arns = [
+    aws_iam_policy.external_secrets.arn
+  ]
+}
+
+resource "aws_iam_policy" "external_secrets" {
+  name        = "external-secrets-policy"
+  description = "Policy for External Secrets Operator"
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+output "external_secrets_irsa_role_arn" {
+  description = "ARN of IAM role for external-secrets"
+  value       = module.external_secrets_irsa_role.iam_role_arn
+}

--- a/terraform/eks-alb-argocd-dns-cert-monitoring/16-external-secret-irsa.yaml
+++ b/terraform/eks-alb-argocd-dns-cert-monitoring/16-external-secret-irsa.yaml
@@ -1,3 +1,31 @@
+# The module creates a Helm release for the External Secrets Operator and Reloader.
+# The Helm releases are configured using values files located in the "values" directory.
+# This module creates an IAM role for the External Secrets Operator to access AWS Secrets Manager.
+# It uses the terraform-aws-modules/iam/aws module to create the role and attach the necessary policies.
+
+resource "helm_release" "external_secrets" {
+  name = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  namespace        = "external-secrets"
+  create_namespace = true
+  version          = "0.16.1"
+
+  values = [file("values/external-secrets-values.yaml")]
+
+}
+
+resource "helm_release" "reloader" {
+  name             = "reloader"
+  repository       = "https://stakater.github.io/stakater-charts"
+  chart            = "stakater-charts"
+  namespace        = "reloader"
+  create_namespace = true
+
+  values = [file("values/reloader-values.yaml")]
+
+}
+
 module "external_secrets_irsa_role" {
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"

--- a/terraform/eks-alb-argocd-dns-cert-monitoring/values/external-secrets-values.yaml
+++ b/terraform/eks-alb-argocd-dns-cert-monitoring/values/external-secrets-values.yaml
@@ -1,0 +1,6 @@
+replicaCount: 1
+
+installCRDs: true
+
+webhook:
+  port: 10250


### PR DESCRIPTION
- The module creates a Helm release for the External Secrets Operator and Reloader.
- The Helm releases are configured using values files located in the "values" directory.
- This module creates an IAM role for the External Secrets Operator to access AWS Secrets Manager.
- It uses the terraform-aws-modules/iam/aws module to create the role and attach the necessary policies.